### PR TITLE
Fix settings sent + custom commands

### DIFF
--- a/src/main/kotlin/com/semgrep/idea/lsp/SemgrepLanguageServer.kt
+++ b/src/main/kotlin/com/semgrep/idea/lsp/SemgrepLanguageServer.kt
@@ -11,10 +11,10 @@ import java.util.concurrent.CompletableFuture
 interface SemgrepLanguageServer : LanguageServer {
     // Requests
     @JsonRequest("semgrep/login")
-    fun login(): CompletableFuture<LoginResult>
+    fun login(params:List<Void> = emptyList()): CompletableFuture<LoginResult>
 
     @JsonRequest("semgrep/loginStatus")
-    fun loginStatus(): CompletableFuture<LoginStatusResult>
+    fun loginStatus(params:List<Void> = emptyList()): CompletableFuture<LoginStatusResult>
 
     // Notifications
     @JsonNotification("semgrep/loginFinish")

--- a/src/main/kotlin/com/semgrep/idea/lsp/SemgrepLspServerDescriptor.kt
+++ b/src/main/kotlin/com/semgrep/idea/lsp/SemgrepLspServerDescriptor.kt
@@ -6,6 +6,8 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.lsp.api.LspServerListener
 import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
 import com.semgrep.idea.settings.AppState
+import com.semgrep.idea.settings.SemgrepLspSettings
+import com.semgrep.idea.settings.TraceLevel
 import org.eclipse.lsp4j.services.LanguageServer
 
 class SemgrepLspServerDescriptor(project: Project) : ProjectWideLspServerDescriptor(project, "Semgrep") {
@@ -16,6 +18,9 @@ class SemgrepLspServerDescriptor(project: Project) : ProjectWideLspServerDescrip
             withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
             withCharset(Charsets.UTF_8)
             addParameter("lsp")
+            if (settingState.trace.server == TraceLevel.VERBOSE){
+                addParameter("--debug")
+            }
         }
     }
 

--- a/src/main/kotlin/com/semgrep/idea/settings/LspSettings.kt
+++ b/src/main/kotlin/com/semgrep/idea/settings/LspSettings.kt
@@ -17,6 +17,7 @@ data class SemgrepLspSettings(
     var scan: Scan = Scan(),
     var doHover: Boolean = false,
     var metrics: Metrics = Metrics(),
+    var pro_intrafile: Boolean = false,
 ) {
 
     data class Trace(var server: TraceLevel = TraceLevel.OFF)
@@ -69,7 +70,7 @@ data class SemgrepLspSettings(
         var isNewAppInstall: Boolean = true,
         var extensionVersion: String = PluginManager.getInstance()
             .findEnabledPlugin(PluginId.findId("com.semgrep.idea")!!)?.version!!,
-        var extenstionType: String = "intellij",
+        var extensionType: String = "intellij",
         // sessionId cannot be generated from intellij easily
         var enabled: Boolean = true,
     )


### PR DESCRIPTION
I had some typos, and for whatever reason the login/loginstatus commands would be sent with a null params field, which would cause crashes. I'm not sure what changed that introduced this but it's now fixed.

## Test plan

Tested with https://github.com/semgrep/semgrep/pull/9310