### PR TITLE
Fix release process

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,6 +131,7 @@ tasks {
     }
 
     publishPlugin {
+        notCompatibleWithConfigurationCache("Uses project copy")
         dependsOn("patchChangelog")
         token = environment("PUBLISH_TOKEN")
         // The pluginVersion is based on the SemVer (https://semver.org) and supports pre-release labels, like 2.1.7-alpha.3


### PR DESCRIPTION
We call prepare sandbox in publishPlugin but apparently disabling it in prepareSandbox doesn't in publish plugin