### PR TITLE
fix: Actually encode uris

### DIFF
--- a/src/main/kotlin/com/semgrep/idea/lsp/FileSaveManager.kt
+++ b/src/main/kotlin/com/semgrep/idea/lsp/FileSaveManager.kt
@@ -4,13 +4,13 @@ import com.intellij.openapi.vfs.newvfs.BulkFileListener
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent
 import org.eclipse.lsp4j.DidSaveTextDocumentParams
 import org.eclipse.lsp4j.TextDocumentIdentifier
-import java.net.URI
+import java.net.URLEncoder
 
 class FileSaveManager(private val semgrepLspServer: SemgrepLspServer) : BulkFileListener {
     override fun after(events: MutableList<out VFileEvent>) {
         val saveEvents = events.filter { it.isFromSave }
         saveEvents.forEach {
-            val uri = URI.create(it.path).toString()
+            val uri = URLEncoder.encode(it.path, "UTF-8")
             val textDocumentIdentifier = TextDocumentIdentifier(uri)
             val params = DidSaveTextDocumentParams(textDocumentIdentifier)
             semgrepLspServer.lsp4jServer.textDocumentService.didSave(params)


### PR DESCRIPTION
I thought that the URI class would encode URIs. It did not

Closes: https://linear.app/semgrep/issue/CDX-484/error-when-scanning-a-project-from-the-intellij-extension-macos

Tested this manually